### PR TITLE
Create ng2-cache.module.ts

### DIFF
--- a/ng2-cache.ts
+++ b/ng2-cache.ts
@@ -6,3 +6,4 @@ export {CacheMemoryStorage} from './src/services/storage/memory/cache-memory.ser
 export {CacheOptionsInterface} from './src/interfaces/cache-options.interface';
 export {CacheSessionStorage} from
     './src/services/storage/session-storage/cache-session-storage.service';
+export {Ng2CacheModule} from './src/ng2-cache.module';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-cache",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Client side caching service for Angular2",
   "main": "ng2-cache.js",
   "repository": {

--- a/src/ng2-cache.module.ts
+++ b/src/ng2-cache.module.ts
@@ -1,0 +1,7 @@
+import { NgModule} from '@angular/core';
+import { CacheService } from './services/cache.service';
+
+@NgModule({
+    providers: [ CacheService ]
+})
+export class Ng2CacheModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     ],
     "files": [
         "ng2-cache.ts",
+        "./src/ng2-cache.module.ts",
         "./src/services/cache.service.ts",
         "./src/services/storage/cache-storage-abstract.service.ts",
         "./src/enums/cache-storages.enum.ts",


### PR DESCRIPTION
Create separate module for `ng2-cache`.
Without this, the user consuming this package has to mention `CacheService` as their own providers in *`@NgModule`* (or as `providers` in component metadata).
When we create separate module for `CacheService` as `Ng2CacheModule` and import, we don't have to do this. This elucidates it more clearly as an external node module/npm package.